### PR TITLE
Skip multi-host setup for nova network setup

### DIFF
--- a/devstack-vm-gate-wrap.sh
+++ b/devstack-vm-gate-wrap.sh
@@ -458,7 +458,7 @@ fi
 if ! function_exists "gate_hook"; then
     # the command we use to run the gate
     function gate_hook {
-        $BASE/new/devstack-gate/devstack-vm-gate.sh
+        $WORKSPACE/devstack-gate/devstack-vm-gate.sh
     }
     export -f gate_hook
 fi

--- a/devstack-vm-gate.sh
+++ b/devstack-vm-gate.sh
@@ -97,13 +97,17 @@ function setup_nova_net_networking {
     # issue with nova net configuring br100 to take over eth0
     # by default.
     # TODO (clarkb): figure out how to make bridge setup sane with ansible.
-    ovs_vxlan_bridge "br_pub" $primary_node "True" 1 \
-                    $FLOATING_HOST_PREFIX $FLOATING_HOST_MASK \
-                    $sub_nodes
-    ovs_vxlan_bridge "br_flat" $primary_node "False" 128 \
-                    $sub_nodes
-    localrc_set $localrc "FLAT_INTERFACE" "br_flat"
-    localrc_set $localrc "PUBLIC_INTERFACE" "br_pub"
+    if [[ "$DEVSTACK_GATE_VIRT_DRIVER" != "xenapi" ]]; then
+        # The following work around shouldn't be applied on xenapi, as xenserver
+        # has vmnet connected on eth3.
+        ovs_vxlan_bridge "br_pub" $primary_node "True" 1 \
+                        $FLOATING_HOST_PREFIX $FLOATING_HOST_MASK \
+                        $sub_nodes
+        ovs_vxlan_bridge "br_flat" $primary_node "False" 128 \
+                        $sub_nodes
+        localrc_set $localrc "FLAT_INTERFACE" "br_flat"
+        localrc_set $localrc "PUBLIC_INTERFACE" "br_pub"
+    fi
 }
 
 function setup_multinode_connectivity {
@@ -463,8 +467,8 @@ function setup_localrc {
         # Add a separate device for volumes
         localrc_set "$localrc_file" "VOLUME_BACKING_DEVICE" "/dev/xvdb"
 
-        # Set multi-host config
-        localrc_set "$localrc_file" "MULTI_HOST" "1"
+        # Disable multi-host
+        localrc_set "$localrc_file" "MULTI_HOST" "False"
     fi
 
     if [[ "$DEVSTACK_GATE_TEMPEST" -eq "1" ]]; then


### PR DESCRIPTION
There is a workaround which always set multi-hosts for Nova
network. It creates a br_flat interface which is connected
to vmnet and DHCP server listens on this interface. But
XenServer has eth3 connected to vmnet. We should use eth3
as the flat interface otherwise the devstack VM has no access
to the guest instances. So we shouldn't apply that workaround
for XenServer. And we currently don't use multi-hosts for
XenServer CI. So let's skipt it.